### PR TITLE
Fix coach signup approval flow

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -34,6 +34,7 @@ export async function GET(request: Request) {
                 id: user.id,
                 email: user.email,
                 role: 'coach',
+                approval_status: 'pending',
                 full_name: deriveFullName(user),
               })
 

--- a/src/app/dashboard/coach-request-history/page.tsx
+++ b/src/app/dashboard/coach-request-history/page.tsx
@@ -1,0 +1,52 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default async function CoachRequestHistoryPage() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !['organizer', 'admin'].includes(profile.role)) {
+    redirect('/dashboard')
+  }
+
+  const { data: requests } = await supabase
+    .from('profiles')
+    .select('id, full_name, email, approval_status, rejection_reason, created_at')
+    .in('approval_status', ['approved', 'rejected', 'pending'])
+    .order('created_at', { ascending: false })
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Coach Request History</h1>
+
+      {requests?.map((coach) => (
+        <div key={coach.id} className="rounded-lg border p-4">
+          <p className="font-semibold">{coach.full_name}</p>
+          <p>{coach.email}</p>
+          <p>Status: {coach.approval_status}</p>
+
+          {coach.rejection_reason && (
+            <p>Reason: {coach.rejection_reason}</p>
+          )}
+
+          <p className="text-sm text-gray-500">
+            Requested on: {new Date(coach.created_at).toLocaleString()}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/dashboard/pending-coaches/actions.ts
+++ b/src/app/dashboard/pending-coaches/actions.ts
@@ -1,0 +1,31 @@
+'use server'
+
+import { createClient } from '../../../lib/supabase/server'
+import { revalidatePath } from 'next/cache'
+
+export async function approveCoach(coachId: string) {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !['organizer', 'admin'].includes(profile.role)) {
+    return
+  }
+
+  await supabase
+    .from('profiles')
+    .update({ approval_status: 'approved' })
+    .eq('id', coachId)
+
+  revalidatePath('/dashboard/pending-coaches')
+}

--- a/src/app/dashboard/pending-coaches/actions.ts
+++ b/src/app/dashboard/pending-coaches/actions.ts
@@ -29,3 +29,33 @@ export async function approveCoach(coachId: string) {
 
   revalidatePath('/dashboard/pending-coaches')
 }
+
+export async function rejectCoach(coachId: string) {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !['organizer', 'admin'].includes(profile.role)) {
+    return
+  }
+
+  await supabase
+    .from('profiles')
+    .update({   
+      approval_status: 'rejected',
+      rejection_reason: 'Unverified coach request',
+    })
+    .eq('id', coachId)
+
+  revalidatePath('/dashboard/pending-coaches')
+}   

--- a/src/app/dashboard/pending-coaches/page.tsx
+++ b/src/app/dashboard/pending-coaches/page.tsx
@@ -1,3 +1,4 @@
+import { approveCoach } from './actions'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 
@@ -30,13 +31,19 @@ export default async function PendingCoachesPage() {
     .order('created_at', { ascending: false })
 
   return (
-        <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Pending Coach Approvals</h1>
+    <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Pending Coach Approvals</h1>
 
-      {pendingCoaches?.map((coach) => (
+        {pendingCoaches?.map((coach) => (
         <div key={coach.id} className="rounded-lg border p-4">
           <p>{coach.full_name}</p>
           <p>{coach.email}</p>
+
+            <form action={approveCoach.bind(null, coach.id)}>
+                <button className="mt-2 rounded bg-black px-3 py-1 text-white">
+                    Approve
+                </button>
+            </form>
         </div>
       ))}
     </div>

--- a/src/app/dashboard/pending-coaches/page.tsx
+++ b/src/app/dashboard/pending-coaches/page.tsx
@@ -1,4 +1,4 @@
-import { approveCoach } from './actions'
+import { approveCoach, rejectCoach } from './actions'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 
@@ -42,6 +42,12 @@ export default async function PendingCoachesPage() {
             <form action={approveCoach.bind(null, coach.id)}>
                 <button className="mt-2 rounded bg-black px-3 py-1 text-white">
                     Approve
+                </button>
+            </form>
+
+            <form action={rejectCoach.bind(null, coach.id)}>
+                <button className="mt-2 ml-2 rounded border px-3 py-1">
+                    Reject
                 </button>
             </form>
         </div>

--- a/src/app/dashboard/pending-coaches/page.tsx
+++ b/src/app/dashboard/pending-coaches/page.tsx
@@ -1,0 +1,44 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default async function PendingCoachesPage() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !['organizer', 'admin'].includes(profile.role)) {
+    redirect('/dashboard')
+  }
+
+  const { data: pendingCoaches } = await supabase
+    .from('profiles')
+    .select('id, full_name, email, created_at')
+    .eq('role', 'coach')
+    .eq('approval_status', 'pending')
+    .order('created_at', { ascending: false })
+
+  return (
+        <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Pending Coach Approvals</h1>
+
+      {pendingCoaches?.map((coach) => (
+        <div key={coach.id} className="rounded-lg border p-4">
+          <p>{coach.full_name}</p>
+          <p>{coach.email}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -1,0 +1,13 @@
+export default function PendingApprovalPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="max-w-md text-center">
+        <h1 className="text-2xl font-bold">Account Pending Approval</h1>
+        <p className="mt-4 text-muted-foreground">
+          Your coach account is awaiting organizer approval.
+          Once approved, you will gain dashboard access.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -38,6 +38,21 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
+  if (user) {
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('approval_status')
+    .eq('id', user.id)
+    .single()
+
+  if (
+    profile?.approval_status !== 'approved' &&
+    request.nextUrl.pathname.startsWith('/dashboard')
+  ) {
+    return NextResponse.redirect(new URL('/pending-approval', request.url))
+  }
+}
+
   if (
     !user &&
     !request.nextUrl.pathname.startsWith('/login') &&

--- a/supabase/migrations/20260415_coach_rejection_history.sql
+++ b/supabase/migrations/20260415_coach_rejection_history.sql
@@ -1,0 +1,2 @@
+alter table profiles
+add column rejection_reason text;

--- a/supabase/migrations/db.sql
+++ b/supabase/migrations/db.sql
@@ -15,6 +15,7 @@ create table profiles (
     id uuid references auth.users on delete cascade primary key,
     email text not null,
     role user_role default 'coach',
+    approval_status text default 'pending', -- pending, approved, rejected
     full_name text,
     created_at timestamptz default now()
 );


### PR DESCRIPTION
Solves issue #47 - unknown coaches accessing dashboard

Added a proper pending approval flow for coach signups.

What changed:

* new coach profiles now start as `pending`
* pending coaches cannot access coach dashboard
* added waiting page for pending approval
* organizer can see pending coach requests
* organizer can approve or reject coach requests
* rejected requests are kept with reason instead of deleting

This should solve the issue of random users getting coach access immediately after signup, even if they do sign up, new coaches won’t directly get dashboard access, organizer can review, approve, or reject them, and rejected ones are kept in history with a reason.
